### PR TITLE
chore: Migrate phishingprotection synth.py to bazel

### DIFF
--- a/grpc-google-cloud-phishingprotection-v1beta1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-phishingprotection-v1beta1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 0.28.3 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/phishingprotection/v1beta1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-phishingprotection-v1beta1/src/main/java/com/google/phishingprotection/v1beta1/PhishingProtectionServiceV1Beta1Grpc.java
+++ b/grpc-google-cloud-phishingprotection-v1beta1/src/main/java/com/google/phishingprotection/v1beta1/PhishingProtectionServiceV1Beta1Grpc.java
@@ -30,7 +30,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/phishingprotection/v1beta1/phishingprotection.proto")
 public final class PhishingProtectionServiceV1Beta1Grpc {
 
@@ -40,30 +40,20 @@ public final class PhishingProtectionServiceV1Beta1Grpc {
       "google.cloud.phishingprotection.v1beta1.PhishingProtectionServiceV1Beta1";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getReportPhishingMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.phishingprotection.v1beta1.ReportPhishingRequest,
-          com.google.phishingprotection.v1beta1.ReportPhishingResponse>
-      METHOD_REPORT_PHISHING = getReportPhishingMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.phishingprotection.v1beta1.ReportPhishingRequest,
           com.google.phishingprotection.v1beta1.ReportPhishingResponse>
       getReportPhishingMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ReportPhishing",
+      requestType = com.google.phishingprotection.v1beta1.ReportPhishingRequest.class,
+      responseType = com.google.phishingprotection.v1beta1.ReportPhishingResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.phishingprotection.v1beta1.ReportPhishingRequest,
           com.google.phishingprotection.v1beta1.ReportPhishingResponse>
       getReportPhishingMethod() {
-    return getReportPhishingMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.phishingprotection.v1beta1.ReportPhishingRequest,
-          com.google.phishingprotection.v1beta1.ReportPhishingResponse>
-      getReportPhishingMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.phishingprotection.v1beta1.ReportPhishingRequest,
             com.google.phishingprotection.v1beta1.ReportPhishingResponse>
@@ -80,10 +70,7 @@ public final class PhishingProtectionServiceV1Beta1Grpc {
                           com.google.phishingprotection.v1beta1.ReportPhishingResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.phishingprotection.v1beta1.PhishingProtectionServiceV1Beta1",
-                              "ReportPhishing"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ReportPhishing"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -105,7 +92,15 @@ public final class PhishingProtectionServiceV1Beta1Grpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static PhishingProtectionServiceV1Beta1Stub newStub(io.grpc.Channel channel) {
-    return new PhishingProtectionServiceV1Beta1Stub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<PhishingProtectionServiceV1Beta1Stub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<PhishingProtectionServiceV1Beta1Stub>() {
+          @java.lang.Override
+          public PhishingProtectionServiceV1Beta1Stub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new PhishingProtectionServiceV1Beta1Stub(channel, callOptions);
+          }
+        };
+    return PhishingProtectionServiceV1Beta1Stub.newStub(factory, channel);
   }
 
   /**
@@ -113,12 +108,28 @@ public final class PhishingProtectionServiceV1Beta1Grpc {
    */
   public static PhishingProtectionServiceV1Beta1BlockingStub newBlockingStub(
       io.grpc.Channel channel) {
-    return new PhishingProtectionServiceV1Beta1BlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<PhishingProtectionServiceV1Beta1BlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<PhishingProtectionServiceV1Beta1BlockingStub>() {
+          @java.lang.Override
+          public PhishingProtectionServiceV1Beta1BlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new PhishingProtectionServiceV1Beta1BlockingStub(channel, callOptions);
+          }
+        };
+    return PhishingProtectionServiceV1Beta1BlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static PhishingProtectionServiceV1Beta1FutureStub newFutureStub(io.grpc.Channel channel) {
-    return new PhishingProtectionServiceV1Beta1FutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<PhishingProtectionServiceV1Beta1FutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<PhishingProtectionServiceV1Beta1FutureStub>() {
+          @java.lang.Override
+          public PhishingProtectionServiceV1Beta1FutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new PhishingProtectionServiceV1Beta1FutureStub(channel, callOptions);
+          }
+        };
+    return PhishingProtectionServiceV1Beta1FutureStub.newStub(factory, channel);
   }
 
   /**
@@ -148,14 +159,14 @@ public final class PhishingProtectionServiceV1Beta1Grpc {
         com.google.phishingprotection.v1beta1.ReportPhishingRequest request,
         io.grpc.stub.StreamObserver<com.google.phishingprotection.v1beta1.ReportPhishingResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getReportPhishingMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getReportPhishingMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getReportPhishingMethodHelper(),
+              getReportPhishingMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.phishingprotection.v1beta1.ReportPhishingRequest,
@@ -173,11 +184,7 @@ public final class PhishingProtectionServiceV1Beta1Grpc {
    * </pre>
    */
   public static final class PhishingProtectionServiceV1Beta1Stub
-      extends io.grpc.stub.AbstractStub<PhishingProtectionServiceV1Beta1Stub> {
-    private PhishingProtectionServiceV1Beta1Stub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<PhishingProtectionServiceV1Beta1Stub> {
     private PhishingProtectionServiceV1Beta1Stub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -207,7 +214,7 @@ public final class PhishingProtectionServiceV1Beta1Grpc {
         io.grpc.stub.StreamObserver<com.google.phishingprotection.v1beta1.ReportPhishingResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getReportPhishingMethodHelper(), getCallOptions()),
+          getChannel().newCall(getReportPhishingMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -221,11 +228,7 @@ public final class PhishingProtectionServiceV1Beta1Grpc {
    * </pre>
    */
   public static final class PhishingProtectionServiceV1Beta1BlockingStub
-      extends io.grpc.stub.AbstractStub<PhishingProtectionServiceV1Beta1BlockingStub> {
-    private PhishingProtectionServiceV1Beta1BlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<PhishingProtectionServiceV1Beta1BlockingStub> {
     private PhishingProtectionServiceV1Beta1BlockingStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -252,8 +255,7 @@ public final class PhishingProtectionServiceV1Beta1Grpc {
      */
     public com.google.phishingprotection.v1beta1.ReportPhishingResponse reportPhishing(
         com.google.phishingprotection.v1beta1.ReportPhishingRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getReportPhishingMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getReportPhishingMethod(), getCallOptions(), request);
     }
   }
 
@@ -265,11 +267,7 @@ public final class PhishingProtectionServiceV1Beta1Grpc {
    * </pre>
    */
   public static final class PhishingProtectionServiceV1Beta1FutureStub
-      extends io.grpc.stub.AbstractStub<PhishingProtectionServiceV1Beta1FutureStub> {
-    private PhishingProtectionServiceV1Beta1FutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<PhishingProtectionServiceV1Beta1FutureStub> {
     private PhishingProtectionServiceV1Beta1FutureStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -298,7 +296,7 @@ public final class PhishingProtectionServiceV1Beta1Grpc {
             com.google.phishingprotection.v1beta1.ReportPhishingResponse>
         reportPhishing(com.google.phishingprotection.v1beta1.ReportPhishingRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getReportPhishingMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getReportPhishingMethod(), getCallOptions()), request);
     }
   }
 
@@ -393,7 +391,7 @@ public final class PhishingProtectionServiceV1Beta1Grpc {
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(
                           new PhishingProtectionServiceV1Beta1FileDescriptorSupplier())
-                      .addMethod(getReportPhishingMethodHelper())
+                      .addMethod(getReportPhishingMethod())
                       .build();
         }
       }

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,34 +1,13 @@
 {
-  "updateTime": "2020-03-19T09:23:04.381166Z",
+  "updateTime": "2020-03-20T05:53:55.664039Z",
   "sources": [
-    {
-      "generator": {
-        "name": "artman",
-        "version": "1.1.1",
-        "dockerImage": "googleapis/artman@sha256:5ef340c8d9334719bc5c6981d95f4a5d2737b0a6a24f2b9a0d430e96fff85c5b"
-      }
-    },
-    {
-      "generator": {
-        "name": "artman",
-        "version": "1.1.1",
-        "dockerImage": "googleapis/artman@sha256:5ef340c8d9334719bc5c6981d95f4a5d2737b0a6a24f2b9a0d430e96fff85c5b"
-      }
-    },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "275fbcce2c900278d487c33293a3c7e1fbcd3a34",
-        "internalRef": "301661567",
-        "log": "275fbcce2c900278d487c33293a3c7e1fbcd3a34\nfeat: pubsub/v1 add an experimental filter field to Subscription\n\nPiperOrigin-RevId: 301661567\n\nf2b18cec51d27c999ad30011dba17f3965677e9c\nFix: UpdateBackupRequest.backup is a resource, not a resource reference - remove annotation.\n\nPiperOrigin-RevId: 301636171\n\n800384063ac93a0cac3a510d41726fa4b2cd4a83\nCloud Billing Budget API v1beta1\nModified api documentation to include warnings about the new filter field.\n\nPiperOrigin-RevId: 301634389\n\n0cc6c146b660db21f04056c3d58a4b752ee445e3\nCloud Billing Budget API v1alpha1\nModified api documentation to include warnings about the new filter field.\n\nPiperOrigin-RevId: 301630018\n\nff2ea00f69065585c3ac0993c8b582af3b6fc215\nFix: Add resource definition for a parent of InspectTemplate which was otherwise missing.\n\nPiperOrigin-RevId: 301623052\n\n55fa441c9daf03173910760191646399338f2b7c\nAdd proto definition for AccessLevel, AccessPolicy, and ServicePerimeter.\n\nPiperOrigin-RevId: 301620844\n\ne7b10591c5408a67cf14ffafa267556f3290e262\nCloud Bigtable Managed Backup service and message proto files.\n\nPiperOrigin-RevId: 301585144\n\nd8e226f702f8ddf92915128c9f4693b63fb8685d\nfeat: Add time-to-live in a queue for builds\n\nPiperOrigin-RevId: 301579876\n\n430375af011f8c7a5174884f0d0e539c6ffa7675\ndocs: add missing closing backtick\n\nPiperOrigin-RevId: 301538851\n\n0e9f1f60ded9ad1c2e725e37719112f5b487ab65\nbazel: Use latest release of gax_java\n\nPiperOrigin-RevId: 301480457\n\n5058c1c96d0ece7f5301a154cf5a07b2ad03a571\nUpdate GAPIC v2 with batching parameters for Logging API\n\nPiperOrigin-RevId: 301443847\n\n"
-      }
-    },
-    {
-      "git": {
-        "name": "synthtool",
-        "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "bcad3e01b69851ad682a87f8202003a1683ad73a"
+        "sha": "c8c8c0bd15d082db9546253dbaad1087c7a9782c",
+        "internalRef": "301843591",
+        "log": "c8c8c0bd15d082db9546253dbaad1087c7a9782c\nchore: use latest gapic-generator in bazel WORKSPACE.\nincluding the following commits from gapic-generator:\n- feat: take source protos in all sub-packages (#3144)\n\nPiperOrigin-RevId: 301843591\n\ne4daf5202ea31cb2cb6916fdbfa9d6bd771aeb4c\nAdd bazel file for v1 client lib generation\n\nPiperOrigin-RevId: 301802926\n\n"
       }
     },
     {
@@ -46,8 +25,7 @@
         "apiName": "phishingprotection",
         "apiVersion": "v1beta1",
         "language": "java",
-        "generator": "gapic",
-        "config": "google/cloud/phishingprotection/artman_phishingprotection_v1beta1.yaml"
+        "generator": "bazel"
       }
     }
   ]

--- a/synth.py
+++ b/synth.py
@@ -14,23 +14,16 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import synthtool as s
-import synthtool.gcp as gcp
 import synthtool.languages.java as java
-
-gapic = gcp.GAPICGenerator()
-common_templates = gcp.CommonTemplates()
 
 versions = ['v1beta1']
 service = 'phishingprotection'
-config_pattern = '/google/cloud/phishingprotection/artman_phishingprotection_{version}.yaml'
 
 for version in versions:
-    java.gapic_library(
+    library = java.bazel_library(
         service=service,
         version=version,
-        config_pattern=config_pattern,
-        package_pattern='com.google.{service}.{version}'
+        bazel_target=f'//google/cloud/{service}/{version}:google-cloud-{service}-{version}-java',
     )
 
 java.common_templates()


### PR DESCRIPTION
The changes in grpc stubs are caused by the gRPC upgrade from 1.10 (more than a year old) to 1.27 (same version which is used as runtime dependency)

